### PR TITLE
Proofreading edits: comments/docstrings/text strings

### DIFF
--- a/English/code/base-object-full.py
+++ b/English/code/base-object-full.py
@@ -1,7 +1,7 @@
 """base-objects-full.py
 
-   This code was written as an sample code 
-   for "FreeCAD Scripting Guide" 
+   This code was written as example code 
+   for the "FreeCAD Scripting Guide" 
      
    Author: Carlo Dormeletti
    Copyright: 2022
@@ -19,7 +19,7 @@ import Part
 DOC_NAME = "base_objects"
 
 def activate_doc():
-    """activate document"""
+    """Activate document"""
     FreeCAD.setActiveDocument(DOC_NAME)
     FreeCAD.ActiveDocument = FreeCAD.getDocument(DOC_NAME)
     FreeCADGui.ActiveDocument = FreeCADGui.getDocument(DOC_NAME)
@@ -27,7 +27,7 @@ def activate_doc():
 
 
 def setview():
-    """Rearrange View"""
+    """Rearrange view"""
     DOC.recompute()
     VIEW.viewAxometric()
     VIEW.setAxisCross(True)
@@ -74,7 +74,7 @@ if FreeCAD.ActiveDocument is None:
 
 # test if there is an active document with a "proper" name
 if FreeCAD.ActiveDocument.Name == DOC_NAME:
-    print("DOC_NAME exist")
+    print("DOC_NAME exists")
 else:
     print("DOC_NAME is not active")
     # test if there is a document with a "proper" name

--- a/English/code/base-tmpl.py
+++ b/English/code/base-tmpl.py
@@ -1,7 +1,7 @@
 """base_tmpl.py
 
-   This code was written as an sample code 
-   for "FreeCAD Scripting Guide" 
+   This code was written as example code 
+   for the "FreeCAD Scripting Guide" 
      
    Author: Carlo Dormeletti
    Copyright: 2022
@@ -19,7 +19,7 @@ import Part
 DOC_NAME = "test_file"
 
 def activate_doc():
-    """activate document"""
+    """Activate document"""
     FreeCAD.setActiveDocument(DOC_NAME)
     FreeCAD.ActiveDocument = FreeCAD.getDocument(DOC_NAME)
     FreeCADGui.ActiveDocument = FreeCADGui.getDocument(DOC_NAME)
@@ -27,7 +27,7 @@ def activate_doc():
 
 
 def setview():
-    """Rearrange View"""
+    """Rearrange view"""
     DOC.recompute()
     VIEW.viewAxometric()
     VIEW.setAxisCross(True)
@@ -72,12 +72,12 @@ if FreeCAD.ActiveDocument is None:
     FreeCAD.newDocument(DOC_NAME)
     print("Document: {0} Created".format(DOC_NAME))
 
-# test if there is an active document with a "proper" name
+# tests if there is an active document with the given name
 if FreeCAD.ActiveDocument.Name == DOC_NAME:
-    print("DOC_NAME exist")
+    print("DOC_NAME exists")
 else:
     print("DOC_NAME is not active")
-    # test if there is a document with a "proper" name
+    # tests if there is a document with the given name
     try:
         FreeCAD.getDocument(DOC_NAME)
     except NameError:
@@ -95,4 +95,4 @@ clear_DOC()
 
 ROT0 = Rotation(0,0,0)
 
-### CODE START HERE ###
+### CODE STARTS HERE ###

--- a/English/code/ext-full.py
+++ b/English/code/ext-full.py
@@ -100,7 +100,7 @@ ROT0 = Rotation(0,0,0)
 ### CODE START HERE ###
 
 def base_figure():
-    """Create a polygon."""
+    """Creates a polygon"""
     points = (
         (0.0, 0.0, 0.0),
         (15.0, 0.0, 0.0),

--- a/English/code/loft-full.py
+++ b/English/code/loft-full.py
@@ -100,7 +100,7 @@ ROT0 = Rotation(0,0,0)
 ### CODE START HERE ###
 
 def base_figure(dim_x, dim_y):
-    """Create a polygon."""
+    """Creates a polygon"""
     points = (
         (0.0, 0.0, 0.0),
         (dim_x, 0.0, 0.0),
@@ -116,7 +116,7 @@ def base_figure(dim_x, dim_y):
 # elements hold created wires
 elements = []
 
-# dimensions hold values that are (dim_x, dim_y, z height) of generating figures
+# dimensions hold values that are (dim_x, dim_y, z height) of generated figures
 dimensions = (
     (5.0, 5.0, 0.0),
     (5.0, 5.0, 5.0),

--- a/English/code/rev-full.py
+++ b/English/code/rev-full.py
@@ -100,7 +100,7 @@ ROT0 = Rotation(0,0,0)
 ### CODE START HERE ###
 
 def base_figure():
-    """Create a polygon."""
+    """Creates a polygon"""
     points = (
         (0.0, 0.0, 0.0),
         (15.0, 0.0, 0.0),


### PR DESCRIPTION
- Made docstring formatting consistent (sentence case, no periods)
- Fixed some mild grammar issues
-"VZOR" and "spess" weren't variable names that made sense to me as an English speaker (not words or clear abbreviations), but I left them as-is since variable names can be anything. It might be worth changing them to something easier to understand since this is example code.
-  I didn't realize that there was a template until I opened that file, so for all files after the template, I ignored the template code, since that can be copy-pasted. 
